### PR TITLE
Remove markdown task based formatting when creating a task

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,6 +1,6 @@
 import { Editor, App, EditorPosition, MarkdownView, Plugin, HeadingCache, PluginSettingTab, Setting, TFile } from 'obsidian';
 import { TodoistApi } from '@doist/todoist-api-typescript'
-import { findWikiLink, line } from './utility';
+import { clearTaskFormatting, findWikiLink, line } from './utility';
 
 interface TodoistLinkSettings {
 	transformToLink: boolean;
@@ -36,6 +36,11 @@ export function findPreviousHeader(line: number, headers: HeadingCache[]): strin
 function prepareTask(line: string, app: any, activeFile: TFile): line {
 	
 	line = line.trim()
+
+	
+	// remove task based markdown
+	line = clearTaskFormatting(line)
+
 	//remove all leading non-alphanumeric characters
 	let lineExternalLinkFormat = line
 	lineExternalLinkFormat = lineExternalLinkFormat.replace(/^[^\\[a-zA-Z0-9]+|[^\\[a-zA-Z0-9]+$/, '')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "obsidian-todoist-link",
-	"version": "2.0.5",
+	"version": "2.2.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "obsidian-todoist-link",
-			"version": "2.0.5",
+			"version": "2.2.0",
 			"license": "MIT",
 			"dependencies": {
 				"@doist/todoist-api-typescript": "^2.1.2"
@@ -19,7 +19,7 @@
 				"builtin-modules": "^3.2.0",
 				"esbuild": "0.13.12",
 				"jest": "^28.1.3",
-				"obsidian": "^0.12.17",
+				"obsidian": "^0.16.0",
 				"ts-jest": "^28.0.7",
 				"tslib": "2.3.1",
 				"typescript": "4.4.4"
@@ -625,6 +625,25 @@
 			"resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
 			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
 			"dev": true
+		},
+		"node_modules/@codemirror/state": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.2.0.tgz",
+			"integrity": "sha512-69QXtcrsc3RYtOtd+GsvczJ319udtBf1PTrr2KbLWM/e2CXUPnh0Nz9AUo8WfhSQ7GeL8dPVNUmhQVgpmuaNGA==",
+			"dev": true,
+			"peer": true
+		},
+		"node_modules/@codemirror/view": {
+			"version": "6.8.1",
+			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.8.1.tgz",
+			"integrity": "sha512-bXWs42i1mnBexaktPABaEpYbt4FbJMnlesObDLF0GE8poRiNaRgm7H/2NfXfD5Swas1ULdFgONLLs4ncwHuz8g==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"@codemirror/state": "^6.1.4",
+				"style-mod": "^4.0.0",
+				"w3c-keyname": "^2.2.4"
+			}
 		},
 		"node_modules/@doist/todoist-api-typescript": {
 			"version": "2.1.2",
@@ -4156,9 +4175,9 @@
 			}
 		},
 		"node_modules/moment": {
-			"version": "2.29.1",
-			"resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-			"integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
+			"version": "2.29.4",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+			"integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
 			"dev": true,
 			"engines": {
 				"node": "*"
@@ -4225,13 +4244,17 @@
 			}
 		},
 		"node_modules/obsidian": {
-			"version": "0.12.17",
-			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-0.12.17.tgz",
-			"integrity": "sha512-YvCAlRym9D8zNPXt6Ez8QubSTVGoChx6lb58zqI13Dcrz3l1lgUO+pcOGDiD5Qa67nzDZLXo3aV2rqkCCpTvGQ==",
+			"version": "0.16.3",
+			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-0.16.3.tgz",
+			"integrity": "sha512-hal9qk1A0GMhHSeLr2/+o3OpLmImiP+Y+sx2ewP13ds76KXsziG96n+IPFT0mSkup1zSwhEu+DeRhmbcyCCXWw==",
 			"dev": true,
 			"dependencies": {
 				"@types/codemirror": "0.0.108",
-				"moment": "2.29.1"
+				"moment": "2.29.4"
+			},
+			"peerDependencies": {
+				"@codemirror/state": "^6.0.0",
+				"@codemirror/view": "^6.0.0"
 			}
 		},
 		"node_modules/once": {
@@ -4892,6 +4915,13 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/style-mod": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.0.0.tgz",
+			"integrity": "sha512-OPhtyEjyyN9x3nhPsu76f52yUGXiZcgvsrFVtvTkyGRQJ0XK+GPc6ov1z+lRpbeabka+MYEQxOYRnt5nF30aMw==",
+			"dev": true,
+			"peer": true
+		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -5183,6 +5213,13 @@
 			"engines": {
 				"node": ">=10.12.0"
 			}
+		},
+		"node_modules/w3c-keyname": {
+			"version": "2.2.6",
+			"resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.6.tgz",
+			"integrity": "sha512-f+fciywl1SJEniZHD6H+kUO8gOnwIr7f4ijKA6+ZvJFjeGi1r4PDLl53Ayud9O/rk64RqgoQine0feoeOU0kXg==",
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/walker": {
 			"version": "1.0.8",

--- a/utility.test.ts
+++ b/utility.test.ts
@@ -1,4 +1,4 @@
-import { findWikiLink } from './utility';
+import { clearTaskFormatting, findWikiLink, isTask } from './utility';
 
 
 test('test find wiki link', () => {
@@ -6,4 +6,87 @@ test('test find wiki link', () => {
         link: "[[Task]]",
         text: "Task",
     }]);
+})
+
+
+
+test('Identifies a task from string that starts with hyphen', () => {
+    const task = isTask('- [x] Task test text')
+    expect(task).toStrictEqual(true);
+    const subtask = isTask('	- [ ] Task test text')
+    expect(subtask).toStrictEqual(true);
+})
+test('Identifies a task from string that starts with asterisk', () => {
+    const task = isTask('* [ ] Task test text')
+    expect(task).toStrictEqual(true);
+    const subtask = isTask('	* [ ] Task test text')
+    expect(subtask).toStrictEqual(true);
+})
+test('Identifies a task from string that starts with a number', () => {
+    const task = isTask('1. [x] Task test text')
+    expect(task).toStrictEqual(true);
+    const subtask = isTask('	1. [x] Task test text')
+    expect(subtask).toStrictEqual(true);
+})
+test('Identifies a task from string that starts with a big number', () => {
+    const task = isTask('909999. [ ] Task test text')
+    expect(task).toStrictEqual(true);
+    const subtask = isTask('	909999. [ ] Task test text')
+    expect(subtask).toStrictEqual(true);
+})
+
+
+test('Does not alter a string not identified as a task', () => {
+    const task = clearTaskFormatting('Sentence that does not contain any task based markdown')
+    expect(task).toEqual('Sentence that does not contain any task based markdown')
+})
+test('Does not alter a string that starts with hyphen', () => {
+    const task = clearTaskFormatting('- Sentence that does not contain any task based markdown')
+    expect(task).toEqual('- Sentence that does not contain any task based markdown')
+    const subtask = clearTaskFormatting('	- Sentence that does not contain any task based markdown')
+    expect(subtask).toEqual('	- Sentence that does not contain any task based markdown')
+})
+test('Does not alter a string that starts with asterisk', () => {
+    const task = clearTaskFormatting('* Sentence that does not contain any task based markdown')
+    expect(task).toEqual('* Sentence that does not contain any task based markdown')
+    const subtask = clearTaskFormatting('	* Sentence that does not contain any task based markdown')
+    expect(subtask).toEqual('	* Sentence that does not contain any task based markdown')
+})
+test('Does not alter a string that starts with a number', () => {
+    const task = clearTaskFormatting('1. Sentence that does not contain any task based markdown')
+    expect(task).toEqual('1. Sentence that does not contain any task based markdown')
+    const subtask = clearTaskFormatting('	1. Sentence that does not contain any task based markdown')
+    expect(subtask).toEqual('	1. Sentence that does not contain any task based markdown')
+})
+test('Does not alter a string that starts with a big number', () => {
+    const task = clearTaskFormatting('909999. Sentence that does not contain any task based markdown')
+    expect(task).toEqual('909999. Sentence that does not contain any task based markdown')
+    const subtask = clearTaskFormatting('	909999. Sentence that does not contain any task based markdown')
+    expect(subtask).toEqual('	909999. Sentence that does not contain any task based markdown')
+})
+
+
+test('Removes task based markdown on a string that starts with hyphen', () => {
+    const task = clearTaskFormatting('- [x] Task test text')
+    expect(task).toEqual('Task test text')
+    const subtask = clearTaskFormatting('	- [x] Task test text')
+    expect(subtask).toEqual('Task test text')
+})
+test('Removes task based markdown on a string that starts with asterisk', () => {
+    const task = clearTaskFormatting('* [ ] Task test text')
+    expect(task).toEqual('Task test text')
+    const subtask = clearTaskFormatting('	* [ ] Task test text')
+    expect(subtask).toEqual('Task test text')
+})
+test('Removes task based markdown on a string that starts with a number', () => {
+    const task = clearTaskFormatting('1. [x] Task test text')
+    expect(task).toEqual('Task test text')
+    const subtask = clearTaskFormatting('	1. [x] Task test text')
+    expect(subtask).toEqual('Task test text')
+})
+test('Removes task based markdown on a string that starts with a big number', () => {
+    const task = clearTaskFormatting('909999. [ ] Task test text')
+    expect(task).toEqual('Task test text')
+    const subtask = clearTaskFormatting('	909999. [ ] Task test text')
+    expect(subtask).toEqual('Task test text')
 })

--- a/utility.ts
+++ b/utility.ts
@@ -11,6 +11,7 @@ interface wikilinkResult {
 }
 
 
+
 export function findWikiLink(line: string): wikilinkResult[] {
 	const match = line.match(/\[\[([^\]]+)\]\]/g)
 	const result: wikilinkResult[] = [] 
@@ -24,4 +25,56 @@ export function findWikiLink(line: string): wikilinkResult[] {
 		}	
 	}
 	return result
+}
+
+
+
+// Matches indentation before a list marker (including > for potentially nested blockquotes or Obsidian callouts)
+const indentationRegex = /^([\s\t>]*)/;
+
+// Matches list markers (-, * 1.)
+const listMarkerRegex = /([-*]|[0-9]+\.)/;
+
+// Matches checkbox and status character inside
+const checkboxRegex = /\[(.)\]/u;
+
+// Match after the checkbox.
+const afterCheckboxRegex = / *(.*)/u;
+
+// Regex for parsing a line, it matches, indentation, list marker, status and the rest of the line
+const taskRegex = new RegExp(
+  indentationRegex.source +
+    listMarkerRegex.source +
+    " +" +
+    checkboxRegex.source +
+    afterCheckboxRegex.source,
+  "u"
+);
+
+/**
+ * Checks to see if a string is a markdowb task according to
+ * obsidian-tasks plugin's rules (but without a tasks plugin dependency)
+ * @param line
+ * @returns boolean
+ */
+export function isTask(line: string): boolean {
+  const regexMatch = line.match(taskRegex);
+  if (regexMatch !== null) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Remove task related markdown from a string
+ * @param line
+ * @returns string without task related markdown
+ */
+export function clearTaskFormatting(line: string): string {
+  if (isTask(line)) {
+    const regexMatch = line.match(taskRegex);
+    // match[4] includes the whole body of the task after the brackets.
+    return regexMatch[4].trim();
+  }
+  return line;
 }


### PR DESCRIPTION
https://github.com/dennisseidel/obsidian-todoist-link/issues/7 was bugging me a little too I fixed it in my local version thought I'd submit a PR for it.

I've based it off the obsidian tasks plugin logic which recognises these formats as tasks. 

```
- [ ]
* [ ]
1. [ ]
909999. [ ]
```

I've also set it up so that in theory in the future [statuses](https://obsidian-tasks-group.github.io/obsidian-tasks/getting-started/statuses/) `[>]`, `[?]` could be mapped to todoist tags.