### PR TITLE
add docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Go to the settings and add your Todoist API Key. You get your todoist API key [h
 
 `Create Todoist Task` will create a new Todoist task in the Inbox from the current line in the Obsidian note and add deeplinks between the two for easy navigation.
 
+## Documentation
+
+For detailed usage instructions and examples, check out the [Docs](https://github.com/your-repo/todoist-link/docs](https://jamiebrynes7.github.io/obsidian-todoist-plugin/docs/overview)).
+
 ## Thanks & Attribution
 
 Thanks to [obsidian-things-link](https://github.com/gavinmn/obsidian-things-link) for providing the initial idea and the basic code to implement the plugin.


### PR DESCRIPTION
Added a link to the plugin documentation in the README -- so users landing on the gh repo can also find the docs :)

<img width="942" height="764" alt="image" src="https://github.com/user-attachments/assets/3d8fae18-0b87-4f37-973f-3cbe2f2282eb" />
